### PR TITLE
[FONCTIONNALITÉ] : Ajout de la pipeline de génération de doc openapi

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,5 +1,5 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Documentation OpenApi
 
 on:
   # Runs on pushes targeting the default branch

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,54 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["dev"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      - name: Deps
+        run: yarn add -g bootprint bootprint-openapi
+
+      - name: Install node_modules
+        run: yarn install
+
+      - name: OpenApi spec
+        run: yarn swagger-gendoc
+
+      - name: Static build
+        run: bootprint openapi src/doc/openapi.json target
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'target'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## 1) Description

Une simple pipeline pour déployer la doc openapi sur github pages.

Cette pipeline va probablement évoluer, ne serait-ce que pour l'aspect du site. 

## 2) Choix technique

La doc est déployée uniquement pour la branche dev car c'est en développement que nous avons besoin de la doc.
Il existe assez peu d'outils pour générer du html depuis une spec openapi, d'où l'utilisation d'un outil ancien.

## 3) Liste de vérification

- [x] Mon code suit les règles de contribution.
- [x] J'ai lu le code de conduite.
- [x] J'ai effectué une relecture de mon code.
- [x] Mes changements n'impliquent pas de nouvelles erreurs ou avertissements.
- [x] Les tests unitaires (nouveaux et anciens) passe localement avec mes nouveaux changements.