### PR TITLE
Fixed incorrect reaction owner

### DIFF
--- a/src/api/routes/social/social_routes.ts
+++ b/src/api/routes/social/social_routes.ts
@@ -127,7 +127,7 @@ _socialRoutes.get('/posts', async (req: express.Request, res: express.Response) 
 	// #swagger.description = 'Endpoint to get a user posts'
 	// #swagger.summary = 'Get posts of the user'
 	if (req.query.userId) {
-		const posts = await PostService.getPosts(req.query.userId.toString());
+		const posts = await PostService.getPosts(req.query.userId.toString(), req.body.user._user_id);
 		res.status(200).json(await Promise.all(posts.map(async (post) => await formatPost(post))));
 	} else {
 		res.status(400).send();

--- a/src/services/social/post_service.ts
+++ b/src/services/social/post_service.ts
@@ -98,7 +98,7 @@ export class PostService {
 			.getOne();
 	}
 
-	static async getPosts(idUtilisateur: string): Promise<Post[]> {
+	static async getPosts(idAuteur: string, idUtilisateur: string): Promise<Post[]> {
 		return await postRepository
 			.createQueryBuilder('post')
 			.leftJoinAndSelect('post.images', 'images')
@@ -106,7 +106,7 @@ export class PostService {
 			.leftJoinAndSelect('post.repost', 'repost')
 			.leftJoinAndSelect('repost.images', 'repostimages')
 			.countReactions(idUtilisateur)
-			.where('post.idUtilisateur = :idUtilisateur', { idUtilisateur })
+			.where('post.idUtilisateur = :idAuteur', { idAuteur })
 			.orderBy('post.dateDeModification', 'DESC')
 			.getMany();
 	}


### PR DESCRIPTION
Si un utilisateur auto-réagissait à ses posts, sa réaction était indiquée comme étant la nôtre.

Ce bug se produisait sur les pages de profil.